### PR TITLE
[Add:]  top / new_plan:no_image.png

### DIFF
--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -51,7 +51,7 @@
 					<h6 class="card-title">
 						<div class="top-user">
 							<%= link_to user_path(article.user_id) do %>
-							<%= attachment_image_tag article.user, :profile_image, :fill, 50, 50, format: "jpeg", class:"img-fluid mx-auto" %>
+							<%= attachment_image_tag article.user, :profile_image, :fill, 50, 50, fallback: "no-image.png", size: "50x50", format: "jpeg", class:"img-fluid mx-auto" %>
 							<% end %>
 
 							<%= link_to user_path(article.user.id), {class: "top-user-name"} do %>


### PR DESCRIPTION
・top画面において、新着プランの表示でユーザーのプロフィールが設定していなければ、no-image_pngが表示されるように変更しました。