### PR TITLE
[Update:]  articles / index / title / truncate(10)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @articles = Article.all
+    @articles = Article.all.page(params[:page]).per(5)
   end
 
   def edit

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -18,7 +18,7 @@
 					<% @articles.each do |article| %>
 					<tr>
 						<td class="article-title">
-							<%= link_to article.title, article_path(article) %>
+							<%= link_to truncate(article.title, length: 10), article_path(article) %>
 						</td>
 
 						<td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,6 +62,8 @@
 					</div>
 				</div>
 				<% end %>
+
+				<%= paginate @articles %>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
・記事の一覧において、タイトルが長すぎるとレイアウトが崩れてしまう事象が発生したので、truncateを採用して10文字以上で途切れるように設定しました。